### PR TITLE
Poprawa błędu identyfikacji

### DIFF
--- a/catan.py
+++ b/catan.py
@@ -140,7 +140,7 @@ def identifyPieces(image, pieces_mask, piece_color):
             except cv2.error:  # Za mały kontur aby wpasować elipsę
                 continue
             (x, y), (Ma, ma), angle = ellipse
-            if Ma / ma > 0.5:  # Jeśli osie elipsy są prawie równe mamy okrąg
+            if Ma / ma > 0.8:  # Jeśli osie elipsy są prawie równe mamy okrąg
                 color = pieces_colors[0]
             else:  # Obiekt jest podłużny
                 color = pieces_colors[1]


### PR DESCRIPTION
Poprawiłem ten błąd identyfikacji. Wartość ilorazu długiej i krótkiej osi elipsy, która pozwalała uznać obiekt za okrągły była  po prostu zbyt niska.
Przy okazji zmieniłem sposób oznaczania pionków, żeby zachować spójność z oznaczeniami pól.
![DeepinScreenshot_select-area_20191122222800](https://user-images.githubusercontent.com/34516276/69461701-6ed5dc00-0d77-11ea-892d-6b1ac267a576.png)
